### PR TITLE
Set opts on the filter.

### DIFF
--- a/app/models/monologue/posts_revision_decorator.rb
+++ b/app/models/monologue/posts_revision_decorator.rb
@@ -13,8 +13,8 @@ Monologue::PostsRevision.class_eval do
 
   def content
     if self.is_markdown? && !in_admin?(caller)
-      pipeline = Content::Pipeline.new([Content::Pipeline::Filters::Markdown, Content::Pipeline::Filters::CodeHighlight], markdown: { type: :gfm, safe: false })
-      return pipeline.filter(read_attribute(:content))
+      pipeline = Content::Pipelinew.new
+      return pipeline.filter(read_attribute(:content), markdown: { type: :gfm, safe: false })
     end
     read_attribute(:content)
   end


### PR DESCRIPTION
This is a subjective change but I thought you might like this better because you wouldn't have the long line at the pipeline creation. Moving the opts onto the filter just makes it so that you do not have to include the list of default filters, but if you really did want to include the default list of filters you can always just do `Content::Pipeline::Filters::DEFAULT_FILTERS` instead of the list that you had that had both of the filters in it.
