### PR TITLE
Fixed compilation of file under therubyracer 0.12.0

### DIFF
--- a/app/assets/javascripts/monologue-markdown/epiceditor_load.coffee.erb
+++ b/app/assets/javascripts/monologue-markdown/epiceditor_load.coffee.erb
@@ -58,7 +58,7 @@ class MonologueMarkdown
     try
       CKEDITOR.instances["post_content"].destroy(true)
       $(@textarea).hide()
-    catch
+    catch error
       #
     $('#cke_post_content').remove()
 


### PR DESCRIPTION
I receive the following error:

``` bash
Error: Parse error on line 61: Unexpected 'TERMINATOR'
  (in /home/geo/.rvm/gems/ruby-1.9.3-p448@r6/bundler/gems/monologue-markdown-5cc4cf2130db/app/assets/javascripts/monologue-markdown/epiceditor_load.coffee.erb)
```

My JS runtime is therubyracer ( 0.12.0 )
